### PR TITLE
fix: correct Docker context paths for Render deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --no-cache-dir poetry==1.7.1
 
 # Copy Poetry files
-COPY pyproject.toml poetry.lock ./
+COPY backend/pyproject.toml backend/poetry.lock ./
 
 # Configure Poetry to not create a virtual environment
 RUN poetry config virtualenvs.create false
@@ -30,7 +30,7 @@ RUN poetry config virtualenvs.create false
 RUN poetry install --no-interaction --no-ansi --no-root --no-dev
 
 # Copy application code
-COPY . .
+COPY backend/ .
 
 # Install the package itself
 RUN poetry install --no-interaction --no-ansi --only-root

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,14 +7,14 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Copy package files
-COPY package.json package-lock.json ./
+COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 
 # Rebuild the source code only when needed
 FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
-COPY . .
+COPY frontend/ .
 
 # Set environment variable for production build
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     name: quadcode-backend
     runtime: docker
     dockerfilePath: ./backend/Dockerfile
-    dockerContext: ./backend
+    dockerContext: .
     plan: free
     envVars:
       - key: PYTHON_VERSION
@@ -26,7 +26,7 @@ services:
     name: quadcode-frontend
     runtime: docker
     dockerfilePath: ./frontend/Dockerfile
-    dockerContext: ./frontend
+    dockerContext: .
     plan: free
     envVars:
       - key: NODE_ENV


### PR DESCRIPTION
Update render.yaml to use root directory as Docker context and adjust Dockerfiles to reference files with backend/ and frontend/ prefixes.